### PR TITLE
Add docs

### DIFF
--- a/docs/backend/config.md
+++ b/docs/backend/config.md
@@ -1,12 +1,18 @@
 # Qualibrate Configuration Guide
 
-This guide describes the structure and contents of the `config.toml` file used by Qualibrate and how to generate this configuration file.
+This guide describes the structure and contents of the `config.toml` file used
+by Qualibrate and how to generate this configuration file.
 
 ## Configuration File: `config.toml`
 
-The `config.toml` file contains configuration settings for Qualibrate and its associated projects. All components of Qualibrate, including the data handler and QuAM DB, can be configured using this file. These configurations are organized into sections, each defined by top-level entries (written as `[entry-name]`).
+The `config.toml` file contains configuration settings for Qualibrate and its
+associated projects. All components of Qualibrate, including the data handler 
+and QuAM DB, can be configured using this file. These configurations are
+organized into sections, each defined by top-level entries (written
+as `[entry-name]`).
 
-The default location for the Qualibrate configuration file is `~/.qualibrate/config.toml`.
+The default location for the Qualibrate configuration file
+is `~/.qualibrate/config.toml`.
 
 ### Qualibrate Top-Level Entry
 
@@ -22,8 +28,11 @@ The `[qualibrate]` section includes general settings for Qualibrate.
 - Default: `"local_storage"`
 - Description: Type of storage.
 - Allowed options:
-  - `"local_storage"`: Use specified local storage as the database.
-  - `"timeline_db"`: Use the [`json timeline database` instance](https://github.com/qua-platform/json-timeline-database) for data interactions. Output results are still stored locally.
+    - `"local_storage"`: Use specified local storage as the database.
+    - `"timeline_db"`: Use
+      the [`json timeline database` instance](https://github.com/qua-platform/json-timeline-database)
+      for data
+      interactions. Output results are still stored locally.
 
 **project**
 
@@ -33,33 +42,42 @@ The `[qualibrate]` section includes general settings for Qualibrate.
 
 - Description: Path to the data root folder of the project.
 - Note: The user storage path should include the project name. For example:
-  - `project = quam_db`
-  - `user_storage = ~/.qualibrate/user_storage/quam_db`
-- Specific results are stored in the format `{user_storage}/%y%m%d/#{id}_{name}_%H%M%S`.
+    - `project = quam_db`
+    - `user_storage = ~/.qualibrate/user_storage/quam_db`
+- Specific results are stored in the
+  format `{user_storage}/%y%m%d/#{id}_{name}_%H%M%S`.
 
 **metadata_out_path**
 
 - Default: `data_path`
-- Description: Field name in metadata that will be used for determining the output path of nodes/snapshots.
+- Description: Field name in metadata that will be used for determining the
+  output path of nodes/snapshots.
 
 ### Qualibrate Timeline Database Top-Level Entry
 
-The `[qualibrate.timeline_db]` section configures the interface between the Qualibrate web app and the QuAM JSON timeline database.
+The `[qualibrate.timeline_db]` section configures the interface between the
+Qualibrate web app and the QuAM JSON
+timeline database.
 
 **spawn**
 
 - Default: `True`
-- Description: Indicates whether to start the `json timeline database` as part of Qualibrate. If `True`, the database will be started at the `/timeline_db` subpath.
+- Description: Indicates whether to start the `json timeline database` as part
+  of Qualibrate. If `True`, the database
+  will be started at the `/timeline_db` subpath.
 
 **address**
 
 - Default: `http://localhost:8000/`
-- Description: Address of the `json timeline database`. If `spawn=True`, the address is automatically set to `http://localhost:8001/timeline_db/`.
+- Description: Address of the `json timeline database`. If `spawn=True`, the
+  address is automatically set
+  to `http://localhost:8001/timeline_db/`.
 
 **timeout**
 
 - Default: `1.0`
-- Description: Time (in seconds) to wait for a response from the `json timeline database`.
+- Description: Time (in seconds) to wait for a response from
+  the `json timeline database`.
 
 ### Example Configuration
 
@@ -79,7 +97,9 @@ timeout = 1.0
 
 ### Configuration with References
 
-It’s possible to use references in the configuration. The reference format is `${#<path to item from the root>}`, where the item path starts with `/`.
+It’s possible to use references in the configuration. The reference format
+is `${#<path to item from the root>}`, where
+the item path starts with `/`.
 
 **Example with References**
 
@@ -111,7 +131,8 @@ qualibrate config [--config-path PATH] [--static-site-files DIRECTORY] [--storag
 
 - Default: `~/.qualibrate/config.toml`
 
-Refer to the [Qualibrate Entry](#qualibrate-entry) section for descriptions of the following options:
+Refer to the [Qualibrate Entry](#qualibrate-top-level-entry) section for
+descriptions of the following options:
 
 **--static-site-files**
 
@@ -133,7 +154,10 @@ Refer to the [Qualibrate Entry](#qualibrate-entry) section for descriptions of t
 
 - Corresponds to the `qualibrate.metadata_out_path` field.
 
-Refer to the [Qualibrate Timeline Database Entry](#qualibrate-timeline-database-entry) section for descriptions of the following options:
+Refer to
+the [Qualibrate Timeline Database Entry](#qualibrate-timeline-database-top-level-entry)
+section for
+descriptions of the following options:
 
 **--spawn-db**
 

--- a/docs/backend/local_storage/local_storage.md
+++ b/docs/backend/local_storage/local_storage.md
@@ -7,28 +7,32 @@ In this example we will assume that:
 - `qualibrate.project`: `qm`
 - `qualibrate.user_storage`: `~/data/${#/qualibrate/project}`
 
-Note that in this example the project `qm` is a folder within the root directory `~/data`.
+Note that in this example the project `qm` is a folder within the root
+directory `~/data`.
 
 ## Expected storage structure
 
 ### Path to project data
-The storage path is chosen with respect to the current project. 
-As a consequence, other projects are stored in directories next to the current project.
+
+The storage path is chosen with respect to the current project. As a
+consequence, other projects are stored in directories next to the current
+project.
 
 **Example**:
 
-| Project name | Project path                  |
-|--------------|-------------------------------|
+| Project name | Project path   |
+|--------------|----------------|
 | qm           | `~/data/qm`    |
 | other        | `~/data/other` |
 
-**Note**: The project name should always be part of the path, but does not have 
-to be the last one. It's always expected that paths would have same structure. This structure can be specified in the configuration file:
+**Note**: The project name should always be part of the path, but does not have
+to be the last one. It's always expected that paths would have same structure.
+This structure can be specified in the configuration file:
 
 `user_storage = ~/storage/${#/project}/data`
 
-| Project name | Project path                       |
-|--------------|------------------------------------|
+| Project name | Project path           |
+|--------------|------------------------|
 | qm           | `~/storage/qm/data`    |
 | other        | `~/storage/other/data` |
 
@@ -37,17 +41,21 @@ to be the last one. It's always expected that paths would have same structure. T
 ### Structure
 
 Each project should have next structure:
-- Subfolders of project path should represent date of experiment. 
-  - Format: `YYYY-MM-DD` (`YYYY` - year, `MM` - month number, `DD` - day number)
-- Subfolders of date should represent node. 
-  - Format: `#<node_id>_<node_name>_HHMMSS`
-    - `node_id` should be unique sequential integer value (index of node), starting at 1.
-    - `node_name` should be string contains latin alphabet symbols, numbers 
-        and `-_`.
-    - `HHMMSS` - time of experiment 
-        (`HH` - hour (24-hour notation), `MM` - minutes, `SS` - seconds)
+
+- Subfolders of project path should represent date of experiment.
+    - Format: `YYYY-MM-DD` (`YYYY` - year, `MM` - month number, `DD` - day
+      number)
+- Subfolders of date should represent node.
+    - Format: `#<node_id>_<node_name>_HHMMSS`
+        - `node_id` should be unique sequential integer value (index of node),
+          starting at 1.
+        - `node_name` should be string contains latin alphabet symbols, numbers
+          and `-_`.
+        - `HHMMSS` - time of experiment
+          (`HH` - hour (24-hour notation), `MM` - minutes, `SS` - seconds)
 
 **Example**:
+
 ```
 ├── 2024-04-24
 │     ├── #1_name1_120000
@@ -65,19 +73,20 @@ Each project should have next structure:
 ### Content of node folder
 
 Files:
+
 - `node.json` --  [required] [common node description](./node_json.md)
 - `state.json` -- [optional] quam snapshot description.
 - `data.json` -- [optional] [output file](#timeline_db-type).
 - Other figures, arrays, and ancillary files.
 
-
-`data.json` file contains output results of experiments. Content should be 
-valid json. It's also possible to have image references (only `.png` is 
+`data.json` file contains output results of experiments. Content should be
+valid json. It's also possible to have image references (only `.png` is
 supported now) in this file. Images path should be subpath of node path.
 
 **Example**:
 
 Files structure:
+
 ```
 2024-04-29
 └── #1_name1_180203

--- a/docs/backend/local_storage/node_json.md
+++ b/docs/backend/local_storage/node_json.md
@@ -1,34 +1,38 @@
 # Node.json
 
-The structure of `node.json` closely mimics the timeline DB snapshot structure in a simplified form.
+The structure of `node.json` closely mimics the timeline DB snapshot structure
+in a simplified form.
 
-- `created_at`: (Required) date + time at which snapshot was stored 
-  - Form: `YYYY-MM-DDTHH:mm:ss±XX:XX` (ISO-8601)
-  - E.g. `'2024-04-16T05:49:55+02:00'`
+- `created_at`: (Required) date + time at which snapshot was stored
+    - Form: `YYYY-MM-DDTHH:mm:ss±XX:XX` (ISO-8601)
+    - E.g. `'2024-04-16T05:49:55+02:00'`
 - `metadata`: (Required) user-specified metadata
-  - Type: `Dict[str, Any]`
-  - Empty dict if no metadata
+    - Type: `Dict[str, Any]`
+    - Empty dict if no metadata
 - `data`: (Optional) container for QuAM data (and other)
-  - Type: `Dict[str, Any]`
-  - Should have top-level entry "quam"
-  - Non-existing if node has no data
-  - Can be JSON reference to external files
+    - Type: `Dict[str, Any]`
+    - Should have top-level entry "quam"
+    - Non-existing if node has no data
+    - Can be JSON reference to external files
 - `id`: (Required) unique identifier for snapshot
-  - Type: `int`
-  - `id` is unique within project
-  - `id` starts at idx 1, and increments by 1 every time
+    - Type: `int`
+    - `id` is unique within project
+    - `id` starts at idx 1, and increments by 1 every time
 - `parents`: (Required) list of parent IDs
-  - Type: `List[int]`
-  - These are a list of parent snapshots 
-  - Usually there is only one, but there can be multiple in case of two branches merging 
-  - If there are multiple branches, the first list id is considered the main branch, and the second list id is the branch that is merged from. 
-  - Empty list if node has no parents 
-  - This usually corresponds to the first node with id=1
+    - Type: `List[int]`
+    - These are a list of parent snapshots
+    - Usually there is only one, but there can be multiple in case of two
+      branches merging
+    - If there are multiple branches, the first list id is considered the main
+      branch, and the second list id is the branch that is merged from.
+    - Empty list if node has no parents
+    - This usually corresponds to the first node with id=1
 
 ### Example
+
 ```json lines
 {
-  "created_at": "2024-04-29T18:02:03+02:00"
+  "created_at": "2024-04-29T18:02:03+02:00",
   "metadata": {
     "name": "node_name",
     "data_path": "2024-03-13/#144_node_name_173039"


### PR DESCRIPTION
Fixes [QUAL-61](https://quantum-machines.atlassian.net/browse/QUAL-61)
- Explanation of `qualibrate config`
- Explanation of each entry in `config.toml`, separated by grouping
- Storage location `~/.qualibrate`, files in storage folder


