### PR TITLE
Fix: Support React 18

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,7 +7,7 @@ import AppRoutes from "./routing/AppRoutes";
 import { BrowserRouter } from "react-router-dom";
 import { updateColorTheme } from "./modules/themeModule/themeHelper";
 import { GlobalThemeContextProvider } from "./modules/themeModule/GlobalThemeContext";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 
 type ProviderComponent = React.FC<PropsWithChildren<ReactNode>>;
 
@@ -28,9 +28,10 @@ const Application: React.FunctionComponent = () => {
   );
 };
 
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!)
+root.render(
   <React.StrictMode>
     <Application />
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );


### PR DESCRIPTION
Chrome is raising an error that React 18 doesn't support `render`
![image](https://github.com/qua-platform/qualibrate-app/assets/6818589/00027e48-cc32-44a1-8588-637dcd99169a)

This PR aims to fix this issue