### PR TITLE
Feat/Switch to live tab when receiving a postmessage

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Qualibrate</title>
 
-    <link rel="shortcut icon" href="/assets/favicon.png"/>
-    <link rel="manifest" href="/manifest.json"/>
+    <link rel="shortcut icon" href="assets/favicon.png"/>
+    <link rel="manifest" href="manifest.json"/>
     <base href="/"/>
     <style>
         .token.operator {

--- a/frontend/src/assets/styles/index.scss
+++ b/frontend/src/assets/styles/index.scss
@@ -6,7 +6,7 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Thin.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Thin.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -16,9 +16,9 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Thin.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Thin.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -27,7 +27,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Light.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Light.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -37,9 +37,9 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Light.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Light.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -48,7 +48,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Regular.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Regular.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -58,9 +58,9 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Regular.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Regular.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -69,7 +69,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Medium.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Medium.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -79,9 +79,9 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url("/assets/fonts/Roboto-Medium.ttf") format("opentype");
+  src: url("assets/fonts/Roboto-Medium.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -90,7 +90,7 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Light.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Light.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -100,9 +100,9 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Light.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Light.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -111,7 +111,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Regular.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Regular.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -121,9 +121,9 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Regular.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Regular.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* latin-ext */
@@ -132,7 +132,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Bold.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Bold.ttf") format("opentype");
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -142,9 +142,9 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/assets/fonts/RobotoCondensed-Bold.ttf") format("opentype");
+  src: url("assets/fonts/RobotoCondensed-Bold.ttf") format("opentype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-  U+2212, U+2215, U+FEFF, U+FFFD;
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 html,

--- a/frontend/src/mainPage/MainModularPage.tsx
+++ b/frontend/src/mainPage/MainModularPage.tsx
@@ -17,7 +17,7 @@ const MainModularPage = () => {
     const checkVersion = async () => {
       const localVersion = localStorage.getItem("appVersion");
       try {
-        const response = await fetch("/manifest.json");
+        const response = await fetch("manifest.json");
         const { version } = await response.json();
 
         if (localVersion && version !== localVersion) {


### PR DESCRIPTION
Currently the switching between live and final happens whenever data is received. Instead, it will now switch to live only when a "postmessage" is received.
The qua dashboard is configured such that it sends this