### PR TITLE
Fix: Decrease graph size when zoomed in

### DIFF
--- a/frontend/src/modules/GraphLibrary/components/CytoscapeGraph/CytoscapeGraph.module.scss
+++ b/frontend/src/modules/GraphLibrary/components/CytoscapeGraph/CytoscapeGraph.module.scss
@@ -7,6 +7,5 @@
   border-radius: var(--border-radius);
   margin-left: 10px;
   margin-right: 10px;
-  width: 100%;
-  height: 400px;
+  height: 100%;
 }

--- a/frontend/src/modules/GraphLibrary/components/GraphElement/GraphElement.module.scss
+++ b/frontend/src/modules/GraphLibrary/components/GraphElement/GraphElement.module.scss
@@ -35,10 +35,12 @@
   flex: 1;
   align-content: center;
   width: 60%;
+  padding-top: 10px;
 }
 
 .leftContainer {
   place-content: center space-between;
+  align-items: center;
   display: flex;
   gap: 10px;
   text-wrap: nowrap;

--- a/frontend/src/modules/GraphLibrary/components/GraphStatus/components/MeasurementElementGraph/MeasurementElementGraph.module.scss
+++ b/frontend/src/modules/GraphLibrary/components/GraphStatus/components/MeasurementElementGraph/MeasurementElementGraph.module.scss
@@ -40,10 +40,13 @@
 
 .wrapper {
   padding-bottom: 10px;
-  height: 530px;
+  height: 50%;
+  display: flex;
+  flex-direction: column;
 }
 
 .insideWrapper {
+  flex: 1;
   max-height: 100%;
   justify-content: space-between;
   font-style: normal;
@@ -57,7 +60,9 @@
 }
 
 .lowerContainer {
-  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   gap: 10px;
 }
 
@@ -94,7 +99,8 @@
 }
 
 .lowerLowerContainer {
+  flex: 1;
   display: flex;
+  flex-direction: column;
   width: 100%;
-  height: 100%;
 }

--- a/frontend/src/modules/GraphLibrary/components/GraphStatus/components/MeasurementHistory/MeasurementHistory.module.scss
+++ b/frontend/src/modules/GraphLibrary/components/GraphStatus/components/MeasurementHistory/MeasurementHistory.module.scss
@@ -1,7 +1,7 @@
 .wrapper {
   font-style: normal;
   font-weight: 500;
-  height: calc(100% - 540px);
+  height: 50%;
 }
 
 .titleRow {

--- a/frontend/src/modules/Nodes/NodesPage.module.scss
+++ b/frontend/src/modules/Nodes/NodesPage.module.scss
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 600px;
+  max-width: 500px;
   overflow: hidden;
   flex-grow: 1;
   color: rgb(217 213 212);


### PR DESCRIPTION
Previously the graph status page showed too much graph when the resolution was low.
This PR fixes this, primarily by introducing flex boxes.
Additionally, the width of the node list has been decreased from 600px to 500px