### PR TITLE
Improve scrolling and layout in JSONEditor and Results components

### DIFF
--- a/frontend/src/modules/Data/components/JSONEditor.tsx
+++ b/frontend/src/modules/Data/components/JSONEditor.tsx
@@ -126,7 +126,7 @@ export const JSONEditor = ({ title, jsonDataProp, height, showSearch = true, tog
         <InputField value={searchTerm} title={"Search"} onChange={(_e, event) => handleSearch(event.target.value, event)}></InputField>
       )}
       <>
-        <div style={{ width: "100%", height: "100%", display: activeTab === "final" ? "block" : "none" }}>
+        <div style={{ width: "100%", height: "100%", display: activeTab === "final" ? "block" : "none", overflowY: "auto" }}>
           <JsonViewer
             rootName={false}
             onSelect={(path) => handleOnSelect(path)}

--- a/frontend/src/modules/Nodes/components/Results/Results.module.scss
+++ b/frontend/src/modules/Nodes/components/Results/Results.module.scss
@@ -3,8 +3,9 @@
 
 .wrapper {
   height: 100%;
-  min-height: 65%;
   border: 1px solid var(--border-color);
   background-color: var(--popup-background);
   padding-bottom: 15px;
+  flex: 1;
+  overflow-y: auto;
 }


### PR DESCRIPTION
- Add vertical scrolling to JSONEditor's final tab view
- Adjust Results component layout to use flex and enable vertical scrolling